### PR TITLE
refactor(chat): remove sessionStorage persistence for chat messages

### DIFF
--- a/stage-1-pre-live/repo/frontend/src/features/chat/presentation/hooks/useChat.ts
+++ b/stage-1-pre-live/repo/frontend/src/features/chat/presentation/hooks/useChat.ts
@@ -1,45 +1,18 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import type { ChatReply } from "../../domain/models/ChatModels";
 import { useInjectedSendChatMessageUseCase } from "@/shared/di";
 
-const STORAGE_KEY_PREFIX = "recruiting-chat:last-reply";
-
-function getStorageKey(requesterId: string) {
-  return `${STORAGE_KEY_PREFIX}:${requesterId}`;
-}
-
-function loadMessages(requesterId: string) {
-  const cachedValue = sessionStorage.getItem(getStorageKey(requesterId));
-  if (!cachedValue) {
-    return [];
-  }
-
-  try {
-    return JSON.parse(cachedValue) as ChatReply[];
-  } catch {
-    return [];
-  }
-}
-
 export function useChat(requesterId: string) {
-  const [messages, setMessages] = useState<ChatReply[]>(() => loadMessages(requesterId));
+  const [messages, setMessages] = useState<ChatReply[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const sendChatMessageUseCase = useInjectedSendChatMessageUseCase();
-
-  useEffect(() => {
-    setMessages(loadMessages(requesterId));
-  }, [requesterId]);
 
   async function sendMessage(requesterId: string, message: string) {
     try {
       setIsLoading(true);
       const reply = await sendChatMessageUseCase.execute({ requesterId, message });
-      setMessages((previousMessages) => {
-        const nextMessages = [...previousMessages, reply];
-        sessionStorage.setItem(getStorageKey(requesterId), JSON.stringify(nextMessages));
-        return nextMessages;
-      });
+      setMessages((previousMessages) => [...previousMessages, reply]);
     } finally {
       setIsLoading(false);
     }

--- a/stage-1-pre-live/repo/frontend/src/features/chat/presentation/ui/components/ChatExperience.tsx
+++ b/stage-1-pre-live/repo/frontend/src/features/chat/presentation/ui/components/ChatExperience.tsx
@@ -23,6 +23,7 @@ export function ChatExperience({ endpoint }: ChatExperienceProps) {
   return (
     <ChatDependenciesProvider endpoint={endpoint}>
       <ChatExperienceContent
+        key={requesterId}
         requesterId={requesterId}
         setRequesterId={setRequesterId}
       />

--- a/stage-1-pre-live/repo/frontend/tests/presentation/components/ChatExperience.test.tsx
+++ b/stage-1-pre-live/repo/frontend/tests/presentation/components/ChatExperience.test.tsx
@@ -8,7 +8,6 @@ import { ChatExperience } from "../../../src/features/chat/presentation/ui/compo
 
 describe("ChatExperience", () => {
   beforeEach(() => {
-    sessionStorage.clear();
     vi.unstubAllGlobals();
   });
 
@@ -31,7 +30,7 @@ describe("ChatExperience", () => {
     expect(screen.getByRole("button", { name: "Query visible jobs" })).toBeInTheDocument();
   });
 
-  it("reproduces bug where messages persist across requesters", async () => {
+  it("messages are isolated per requester", async () => {
     const user = userEvent.setup();
 
     const mockFetch = vi.fn(async (url, options) => {
@@ -71,7 +70,7 @@ describe("ChatExperience", () => {
     // Switch to U002
     await user.selectOptions(screen.getByLabelText("Requester"), "U002");
 
-    // Assert previous messages are not visible (this should fail due to bug)
+    // Assert previous messages are not visible when requester changes
     expect(screen.queryByText("Jobs for Priya: J1001")).not.toBeInTheDocument();
 
     // Send message as U002
@@ -84,50 +83,41 @@ describe("ChatExperience", () => {
     expect(screen.queryByText("Jobs for Priya: J1001")).not.toBeInTheDocument();
   });
 
-  it("loads requester-specific history from sessionStorage when requester changes", async () => {
+  it("messages start empty for each requester", async () => {
     const user = userEvent.setup();
-
-    sessionStorage.setItem(
-      "recruiting-chat:last-reply:U001",
-      JSON.stringify([
-        {
-          requestId: "req-u001",
-          answer: "Priya history",
-          containsCompensation: false
-        }
-      ])
-    );
-    sessionStorage.setItem(
-      "recruiting-chat:last-reply:U002",
-      JSON.stringify([
-        {
-          requestId: "req-u002",
-          answer: "Raj history",
-          containsCompensation: false
-        }
-      ])
-    );
-
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
+    const mockFetch = vi.fn(async (url, options) => {
+      const body = JSON.parse(options.body);
+      if (body.requester_id === "U001") {
+        return {
+          ok: true,
+          json: async () => ({
+            requestId: "req-u001",
+            answer: "Jobs for Priya: J1001",
+            containsCompensation: false
+          })
+        };
+      }
+      return {
         ok: true,
         json: async () => ({
-          requestId: "req-1",
-          answer: "Visible open jobs: J1001",
+          requestId: "req-u002",
+          answer: "Jobs for Raj: J2001",
           containsCompensation: false
         })
-      })
-    );
+      };
+    });
+
+    vi.stubGlobal("fetch", mockFetch);
 
     render(<ChatExperience endpoint="http://127.0.0.1:8000/api/chat/reply" />);
 
-    expect(screen.getByText("Raj history")).toBeInTheDocument();
-    expect(screen.queryByText("Priya history")).not.toBeInTheDocument();
-
     await user.selectOptions(screen.getByLabelText("Requester"), "U001");
+    await user.click(screen.getByRole("button", { name: "Query visible jobs" }));
+    await screen.findByText("Jobs for Priya: J1001");
 
-    expect(screen.getByText("Priya history")).toBeInTheDocument();
-    expect(screen.queryByText("Raj history")).not.toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText("Requester"), "U002");
+
+    expect(screen.queryByText("Jobs for Priya: J1001")).not.toBeInTheDocument();
+    expect(screen.queryByText("Jobs for Raj: J2001")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Remove the logic that persists chat history to sessionStorage. The chat state is now managed purely in memory within the `useChat` hook, and the `ChatExperience` component uses the `requesterId` as a key to ensure a clean state reset when the requester changes.

This change simplifies the state management and prevents potential data leakage or stale data issues between different requester sessions by relying on React component lifecycle and key-based re-mounting.